### PR TITLE
Stale images

### DIFF
--- a/src/aci/game_capture/inference.py
+++ b/src/aci/game_capture/inference.py
@@ -39,8 +39,10 @@ class GameCapture(mp.Process):
 
         image, state = self._get_capture()
         self.is_stale = True
+        is_image_stale = self._is_cached_image_stale
         state = self._state_transform(state, self._simulated_INS)
-        return {"state": state, "image": image}
+        self._is_cached_image_stale = True
+        return {"state": state, "image": image, "is_image_stale": is_image_stale}
 
     def _get_capture(self):
         image_mp_array, _ = self._shared_image_buffer
@@ -55,6 +57,7 @@ class GameCapture(mp.Process):
         if not self.is_image_stale:
             self._copy_image(image_np_array)
             self.is_image_stale = True
+            self._is_cached_image_stale = False
 
     def _copy_image(self, image: np.array):
         self._image = image.copy()
@@ -217,6 +220,7 @@ class GameCapture(mp.Process):
         width, height = self._image_stream_config["resolution"]
         n_channels = 4 if self._image_stream_config["image_format"] == "BGR0" else 3
         self._image_shape = (height, width, n_channels)
+        self._is_cached_image_stale = True
 
     def __setup_state_postprocessing(self):
         self._simulated_INS = SimulatedINS()

--- a/src/aci/metrics/database/state_logger.py
+++ b/src/aci/metrics/database/state_logger.py
@@ -87,6 +87,7 @@ class DatabaseStateInterface(PostgresConnector):
         self._update_timestamps(state)
         self._add_cumulative_time(state)
         python_types_state = convert_numpy_types(state)
+        logger.info(python_types_state)
         self._insert_dict(python_types_state)
 
     def _format_dictionary(self, state: Dict):

--- a/src/aci/utils/load.py
+++ b/src/aci/utils/load.py
@@ -57,10 +57,9 @@ def state_bytes_to_dict(data: bytes) -> Dict:
     """
     state_array = np.frombuffer(data, COMBINED_DATA_TYPES)
     state_dict = {
-        key[0]: value for key, value in zip(COMBINED_DATA_TYPES, state_array[0])
+        key[0]: value.tobytes().decode("utf-8") if key in STRING_KEYS else value
+        for key, value in zip(COMBINED_DATA_TYPES, state_array[0])
     }
-    for string_key in STRING_KEYS:
-        state_dict[string_key] = state_dict[string_key].tobytes().decode("utf-8")
     return state_dict
 
 

--- a/src/aci/utils/load.py
+++ b/src/aci/utils/load.py
@@ -57,7 +57,7 @@ def state_bytes_to_dict(data: bytes) -> Dict:
     """
     state_array = np.frombuffer(data, COMBINED_DATA_TYPES)
     state_dict = {
-        key[0]: value.tobytes().decode("utf-8") if key in STRING_KEYS else value
+        key[0]: value.tobytes().decode("utf-8") if key[0] in STRING_KEYS else value
         for key, value in zip(COMBINED_DATA_TYPES, state_array[0])
     }
     return state_dict


### PR DESCRIPTION
Improved handling of image captures accounting for frames that are reused by the harness. 

Previously the frame was copied from the buffer regardless of whether it had been updated. This copy now only occurs when the frame has been updated by the video capture thread. Instead if the frame has not been updated the previous frame is reused. A flag, `is_image_stale` is also included with the observation dictionary provided indicating whether it is a stale frame.