### PR TITLE
Restart Session

### DIFF
--- a/src/aci/interface.py
+++ b/src/aci/interface.py
@@ -10,6 +10,7 @@ from aci.input.controller import VirtualGamepad
 from aci.launchers import get_ac_launcher
 from aci.metrics.database.monitor import Evaluator
 from aci.metrics.database.state_logger import DatabaseStateLogger
+from aci.monitor import RestartMonitor, TerminationMonitor
 from loguru import logger
 import numpy as np
 
@@ -86,15 +87,13 @@ class AssettoCorsaInterface(abc.ABC):
         self._initialise_AC()
         self._initialise_capture()
         self._initialise_evaluation()
-        self._setup_termination_check()
+        self._setup_monitors()
 
-    def _setup_termination_check(self):
-        self._n_steps_since_last_check = 0
+    def _setup_monitors(self):
+        restart_config = self._config.get("restart", {})
+        self._restart_monitor = RestartMonitor(restart_config, self)
         termination_config = self._config.get("termination", {})
-        self._n_steps_between_checks = termination_config.get("check_every_n", -1)
-        self._n_consecutive_failures = 0
-        max_consecutive_failures = termination_config.get("max_consecutive_failures", 0)
-        self._n_max_consecutive_failures = max_consecutive_failures
+        self._termination_monitor = TerminationMonitor(termination_config, self)
 
     def _initialise_AC(self):
         self._ac_launcher = get_ac_launcher(self._config)
@@ -158,15 +157,14 @@ class AssettoCorsaInterface(abc.ABC):
         self._launch_AC()
         self._start_capture()
         self._start_evaluation()
-        self._ac_launcher.start_session()
-        time.sleep(2)
+        self._start_session()
         while self.is_running:
             try:
                 observation = self.get_observation()
-                if self._is_termination_condition_met(observation):
-                    self.is_running = False
+                self._maybe_terminate_session(observation)
                 action = self.behaviour(observation)
                 self.act(action)
+                self._maybe_restart_session(observation)
             except KeyboardInterrupt:
                 self.is_running = False
             except Exception as e:
@@ -175,23 +173,23 @@ class AssettoCorsaInterface(abc.ABC):
         self.teardown()
         self._shutdown()
 
-    def _is_termination_condition_met(self, observation: Dict) -> bool:
-        if self._n_steps_between_checks < 0:
-            return False
-        if self._n_steps_between_checks > self._n_steps_since_last_check:
-            self._n_steps_since_last_check += 1
-            return False
-        self._n_steps_since_last_check = 0
-        if self.termination_condition(observation):
-            self._n_consecutive_failures += 1
-        else:
-            self._n_consecutive_failures = 0
-        if self._n_consecutive_failures >= self._n_max_consecutive_failures:
-            message = "Agent has met the termination condition "
-            message += f"{self._n_consecutive_failures} times. Terminating execution"
-            logger.error(message)
-            return True
-        return False
+    def _start_session(self):
+        self._ac_launcher.start_session()
+        time.sleep(2)
+
+    def _maybe_terminate_session(self, observation: Dict):
+        if self._termination_monitor.is_triggered(observation):
+            self.is_running = False
+
+    def _maybe_restart_session(self, observation: Dict):
+        if self._restart_monitor.is_triggered(observation):
+            self._restart_session()
+
+    def _restart_session(self):
+        self._ac_launcher.restart_session()
+        self._termination_monitor.reset()
+        self._restart_monitor.reset()
+        time.sleep(2)
 
     def _log_exception(self, exception: Exception):
         message = "Agent has thrown an exception and will now terminate. "
@@ -248,11 +246,23 @@ class AssettoCorsaInterface(abc.ABC):
     @abc.abstractmethod
     def termination_condition(self, observation: Dict) -> bool:
         """
-        Implement a condition based on simulation observation that is met will cause
+        Implement a condition based on simulation observation that when met will cause
             the current experiment to terminate
 
         :observation: {Dictionary image: BGR image as np.array, state: Dict{str: float}}
         :type: Dict[str: np.array]
         :return: True to terminate agent execution, False to continue
+        :rtype: bool
+        """
+
+    @abc.abstractmethod
+    def restart_condition(self, observation: Dict) -> bool:
+        """
+        Implement a condition based on simulation observation that when met will cause
+            the current session to be restarted
+
+        :observation: {Dictionary image: BGR image as np.array, state: Dict{str: float}}
+        :type: Dict[str: np.array]
+        :return: True to restart the session, False to continue
         :rtype: bool
         """

--- a/src/aci/launchers/base.py
+++ b/src/aci/launchers/base.py
@@ -129,6 +129,33 @@ class AssettoCorsaLauncher(abc.ABC):
         pyautogui.click(top_left_corner.x + 20, top_left_corner.y + 150)
         pyautogui.moveTo(cursor_location)
 
+    def restart_session(self):
+        """
+        Restart a running session without closing the window
+        """
+        self._click_restart_session()
+        self.start_session()
+
+    def _click_restart_session(self):
+        """
+        Opens the menue and clicks the restart session option
+        """
+        cursor_location = pyautogui.position()
+        top_left_corner = get_application_window_coordinates(
+            "AC", self._window_resolution
+        )
+        width, height = self._window_resolution
+        restart_session_x = top_left_corner.x + width // 2
+        restart_session_y = top_left_corner.y + height // 2 + 15
+        # Click on the centre of the window so keypress is detected
+        pyautogui.click(restart_session_x, restart_session_y)
+        # Open menu and click "Restart Session"
+        pyautogui.press("escape")
+        pyautogui.click(restart_session_x, restart_session_y)
+        pyautogui.moveTo(cursor_location)
+        # Wait for window to load
+        time.sleep(2)
+
     def _load_vehicle_setup(self):
         """
         Clicks in the AC window to load the vehicle setup in the top position of the UI

--- a/src/aci/launchers/base.py
+++ b/src/aci/launchers/base.py
@@ -154,7 +154,7 @@ class AssettoCorsaLauncher(abc.ABC):
         pyautogui.click(restart_session_x, restart_session_y)
         pyautogui.moveTo(cursor_location)
         # Wait for window to load
-        time.sleep(2)
+        time.sleep(1)
 
     def _load_vehicle_setup(self):
         """

--- a/src/aci/monitor/__init__.py
+++ b/src/aci/monitor/__init__.py
@@ -1,0 +1,4 @@
+from .restart import RestartMonitor
+from .termination import TerminationMonitor
+
+__all__ = ["TerminationMonitor", "RestartMonitor"]

--- a/src/aci/monitor/base.py
+++ b/src/aci/monitor/base.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import abc
 from typing import Dict
 
@@ -6,10 +7,10 @@ from loguru import logger
 
 
 class AgentMonitor(abc.ABC):
-    def __init__(self, config: Dict, interface: AssettoCorsaInterface):
+    def __init__(self, config: Dict, interface):
         self._setup(config, interface)
 
-    def _setup(self, config: Dict, interface: AssettoCorsaInterface):
+    def _setup(self, config: Dict, interface):
         self._interface = interface
         self._n_steps_between_checks = config.get("check_every_n", -1)
         self._n_max_consecutive_failures = config.get("max_consecutive_failures", 0)

--- a/src/aci/monitor/base.py
+++ b/src/aci/monitor/base.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+import abc
+from typing import Dict
+
+from loguru import logger
+
+
+class AgentMonitor(abc.ABC):
+    def __init__(self, config: Dict, interface: AssettoCorsaInterface):
+        self._setup(config, interface)
+
+    def _setup(self, config: Dict, interface: AssettoCorsaInterface):
+        self._interface = interface
+        self._n_steps_between_checks = config.get("check_every_n", -1)
+        self._n_max_consecutive_failures = config.get("max_consecutive_failures", 0)
+        self.reset()
+
+    def reset(self):
+        self._n_steps_since_last_check = 0
+        self._n_consecutive_failures = 0
+
+    def is_triggered(self, observation: Dict) -> bool:
+        if self._is_monitor_disabled:
+            return False
+
+        if self._is_unmonitored_interval:
+            self._n_steps_since_last_check += 1
+            return False
+
+        self._check_monitored_condition(observation)
+        return self._is_monitor_triggered
+
+    @property
+    def _is_monitor_disabled(self) -> bool:
+        return self._n_steps_between_checks < 0
+
+    @property
+    def _is_unmonitored_interval(self) -> bool:
+        return self._n_steps_between_checks > self._n_steps_since_last_check
+
+    def _check_monitored_condition(self, observation: Dict):
+        if self._is_monitored_condition_met(observation):
+            self._n_consecutive_failures += 1
+        else:
+            self._n_consecutive_failures = 0
+        self._n_steps_since_last_check = 0
+
+    @abc.abstractmethod
+    def _is_monitored_condition_met(self, observation: Dict) -> bool:
+        """
+        Return the value produced by the user defined abstract condition function
+            on the interface class here. Either "termination_condition" or
+            "restart_condition"
+        """
+        pass
+
+    @property
+    def _is_monitor_triggered(self) -> bool:
+        if self._is_patience_exhausted:
+            self._log_exhaustion()
+            return True
+        return False
+
+    @property
+    def _is_patience_exhausted(self) -> bool:
+        return self._n_consecutive_failures >= self._n_max_consecutive_failures
+
+    def _log_exhaustion(self):
+        logger.error(self._get_exhaustion_message())
+
+    @abc.abstractmethod
+    def _get_exhaustion_message(self) -> str:
+        """
+        Return the message to be logged on exhaustion of monitor patience
+        """
+        pass

--- a/src/aci/monitor/restart.py
+++ b/src/aci/monitor/restart.py
@@ -1,0 +1,16 @@
+from typing import Dict
+
+from .base import AgentMonitor
+
+
+class RestartMonitor(AgentMonitor):
+    def _is_monitored_condition_met(self, observation: Dict) -> bool:
+        return self._interface.restart_condition(observation)
+
+    def _get_exhaustion_message(self) -> str:
+        """
+        Return the message to be logged on exhaustion of monitor patience
+        """
+        message = "Agent has met the restart condition "
+        message += f"{self._n_consecutive_failures} times. Session Restarting..."
+        return message

--- a/src/aci/monitor/termination.py
+++ b/src/aci/monitor/termination.py
@@ -1,0 +1,16 @@
+from typing import Dict
+
+from .base import AgentMonitor
+
+
+class TerminationMonitor(AgentMonitor):
+    def _is_monitored_condition_met(self, observation: Dict) -> bool:
+        return self._interface.termination_condition(observation)
+
+    def _get_exhaustion_message(self) -> str:
+        """
+        Return the message to be logged on exhaustion of monitor patience
+        """
+        message = "Agent has met the termination condition "
+        message += f"{self._n_consecutive_failures} times. Terminating execution"
+        return message


### PR DESCRIPTION
Added functionality to reset the current session on the same circuit without closing and reopening the simulator.
Agents derived from ACI will now need to implement a `restart_condition` method which will operate in the same manner as `termination_condition`, but when it is triggered a configurable number of times it will restart the session instead of terminating the session.

This will enable soft-reset of the environment for RL agents